### PR TITLE
Issue 43117

### DIFF
--- a/sca/security_stack/output.tf
+++ b/sca/security_stack/output.tf
@@ -61,3 +61,13 @@ output "public_nic_ids" {
     internal = module.internal.public_nic_ids
   }
 }
+
+# BIG-IP map
+output "bigips_map" {
+  description = "Map of the deployed BIG-IPs and their network information"
+  value = {
+    external = local.external_bigip_map
+    ips      = local.ips_bigip_map
+    internal = local.internal_bigip_map
+  }
+}

--- a/sca/security_stack/output.tf
+++ b/sca/security_stack/output.tf
@@ -68,6 +68,6 @@ output "bigip_map" {
   value = {
     external = module.external.bigip_map
     ips      = module.ips.bigip_map
-    internal = module.bigip_map
+    internal = module.internal.bigip_map
   }
 }

--- a/sca/security_stack/output.tf
+++ b/sca/security_stack/output.tf
@@ -63,11 +63,11 @@ output "public_nic_ids" {
 }
 
 # BIG-IP map
-output "bigips_map" {
+output "bigip_map" {
   description = "Map of the deployed BIG-IPs and their network information"
   value = {
-    external = local.external_bigip_map
-    ips      = local.ips_bigip_map
-    internal = local.internal_bigip_map
+    external = module.external.bigip_map
+    ips      = module.ips.bigip_map
+    internal = module.bigip_map
   }
 }


### PR DESCRIPTION
fixes [AB#43117](https://dev.azure.com/f5eng/1969f822-cce2-4965-baeb-b0253d28034f/_workitems/edit/43117), adds bigip_map to security_stack output so configuration management processes will have a dictionary of BIGP-IP objects with corresponding IPs. 