### PR TITLE
pin terraform providers for core

### DIFF
--- a/sca/core/provider.tf
+++ b/sca/core/provider.tf
@@ -1,3 +1,10 @@
 provider "aws" {
   region = var.aws_region
 }
+
+terraform {
+  required_providers {
+    aws = "~> 2.59"
+    random = "~> 2.2"
+  }
+}

--- a/sca/security_stack/provider.tf
+++ b/sca/security_stack/provider.tf
@@ -1,3 +1,10 @@
 provider "aws" {
   region = var.aws_region.value
 }
+
+terraform {
+  required_providers {
+    aws = "~> 2.59"
+    template = "~> 2.1"
+  }
+}


### PR DESCRIPTION
recommended practice for pinning provider versions to avoid accidental breaking changes