### PR TITLE
Work moleary DO for IPS and Internal tiers

### DIFF
--- a/sca/configuration_stack/declarativeOnboarding.tf
+++ b/sca/configuration_stack/declarativeOnboarding.tf
@@ -29,7 +29,7 @@ locals {
   ])
 }
 locals {
-  ips_bigips = flatten([
+  ips_bigip_az1 = flatten([
     for environment, bigips in var.bigip_map.value : [
       for key, bigip in bigips : {
         id : key
@@ -40,11 +40,11 @@ locals {
           }
         }
       }
-    ] if(environment == "ips")
+    ] if(environment == "ips_az1")
   ])
 }
 locals {
-  internal_bigips = flatten([
+  ips_bigip_az2 = flatten([
     for environment, bigips in var.bigip_map.value : [
       for key, bigip in bigips : {
         id : key
@@ -55,7 +55,37 @@ locals {
           }
         }
       }
-    ] if(environment == "internal")
+    ] if(environment == "ips_az2")
+  ])
+}
+locals {
+  internal_bigip_az1 = flatten([
+    for environment, bigips in var.bigip_map.value : [
+      for key, bigip in bigips : {
+        id : key
+        subnets : {
+          for subnet, data in bigip : data.attachment[0].device_index => {
+            private_ip : data.private_ip,
+            private_dns_name : data.private_dns_name
+          }
+        }
+      }
+    ] if(environment == "internal_az1")
+  ])
+}
+locals {
+  internal_bigip_az2 = flatten([
+    for environment, bigips in var.bigip_map.value : [
+      for key, bigip in bigips : {
+        id : key
+        subnets : {
+          for subnet, data in bigip : data.attachment[0].device_index => {
+            private_ip : data.private_ip,
+            private_dns_name : data.private_dns_name
+          }
+        }
+      }
+    ] if(environment == "internal_az2")
   ])
 }
 
@@ -115,14 +145,14 @@ data "template_file" "ips_bigip_az1_do_json" {
   vars = {
     #Uncomment the following line for BYOL
     #local_sku	    = "${var.license1}"
-    host1	        = local.ips_bigips[0].subnets.0.private_ip
-    host2	        = local.ips_bigips[1].subnets.0.private_ip
-    local_host      = local.ips_bigips[0].subnets.0.private_dns_name
-    local_selfip    = local.ips_bigips[0].subnets.1.private_ip
-    local_selfip2   = local.ips_bigips[0].subnets.2.private_ip
-    local_selfip3   = local.ips_bigips[0].subnets.3.private_ip
-    remote_host	    = local.ips_bigips[1].subnets.0.private_dns_name
-    remote_selfip   = local.ips_bigips[1].subnets.2.private_ip
+    host1	        = local.ips_bigip_az1[0].subnets.0.private_ip
+    host2	        = local.ips_bigip_az2[0].subnets.0.private_ip
+    local_host      = local.ips_bigip_az1[0].subnets.0.private_dns_name
+    local_selfip    = local.ips_bigip_az1[0].subnets.1.private_ip
+    local_selfip2   = local.ips_bigip_az1[0].subnets.2.private_ip
+    local_selfip3   = local.ips_bigip_az1[0].subnets.3.private_ip
+    remote_host	    = local.ips_bigip_az2[0].subnets.0.private_dns_name
+    remote_selfip   = local.ips_bigip_az2[0].subnets.2.private_ip
     gateway	        = var.ips0_gateway
     dns_server	    = var.dns_server
     ntp_server	    = var.ntp_server
@@ -138,14 +168,14 @@ data "template_file" "ips_bigip_az2_do_json" {
   vars = {
     #Uncomment the following line for BYOL
     #local_sku	    = "${var.license1}"
-    host1	        = local.ips_bigips[0].subnets.0.private_ip
-    host2	        = local.ips_bigips[1].subnets.0.private_ip
-    local_host      = local.ips_bigips[1].subnets.0.private_dns_name
-    local_selfip    = local.ips_bigips[1].subnets.1.private_ip
-    local_selfip2   = local.ips_bigips[1].subnets.2.private_ip
-    local_selfip3   = local.ips_bigips[1].subnets.3.private_ip
-    remote_host	    = local.ips_bigips[0].subnets.0.private_dns_name
-    remote_selfip   = local.ips_bigips[0].subnets.2.private_ip
+    host1	        = local.ips_bigip_az1[0].subnets.0.private_ip
+    host2	        = local.ips_bigip_az2[0].subnets.0.private_ip
+    local_host      = local.ips_bigip_az2[0].subnets.0.private_dns_name
+    local_selfip    = local.ips_bigip_az2[0].subnets.1.private_ip
+    local_selfip2   = local.ips_bigip_az2[0].subnets.2.private_ip
+    local_selfip3   = local.ips_bigip_az2[0].subnets.3.private_ip
+    remote_host	    = local.ips_bigip_az1[0].subnets.0.private_dns_name
+    remote_selfip   = local.ips_bigip_az1[0].subnets.2.private_ip
     gateway	        = var.ips1_gateway
     dns_server	    = var.dns_server
     ntp_server	    = var.ntp_server
@@ -160,14 +190,14 @@ data "template_file" "internal_bigip_az1_do_json" {
   vars = {
     #Uncomment the following line for BYOL
     #local_sku	    = "${var.license1}"
-    host1	        = local.internal_bigips[0].subnets.0.private_ip
-    host2	        = local.internal_bigips[1].subnets.0.private_ip
-    local_host      = local.internal_bigips[0].subnets.0.private_dns_name
-    local_selfip    = local.internal_bigips[0].subnets.1.private_ip
-    local_selfip2   = local.internal_bigips[0].subnets.2.private_ip
-    local_selfip3   = local.internal_bigips[0].subnets.3.private_ip
-    remote_host	    = local.internal_bigips[1].subnets.0.private_dns_name
-    remote_selfip   = local.internal_bigips[1].subnets.2.private_ip
+    host1	        = local.internal_bigip_az1[0].subnets.0.private_ip
+    host2	        = local.internal_bigip_az2[0].subnets.0.private_ip
+    local_host      = local.internal_bigip_az1[0].subnets.0.private_dns_name
+    local_selfip    = local.internal_bigip_az1[0].subnets.1.private_ip
+    local_selfip2   = local.internal_bigip_az1[0].subnets.2.private_ip
+    local_selfip3   = local.internal_bigip_az1[0].subnets.3.private_ip
+    remote_host	    = local.internal_bigip_az2[0].subnets.0.private_dns_name
+    remote_selfip   = local.internal_bigip_az2[0].subnets.2.private_ip
     gateway	        = var.int0_gateway
     dns_server	    = var.dns_server
     ntp_server	    = var.ntp_server
@@ -183,14 +213,14 @@ data "template_file" "internal_bigip_az2_do_json" {
   vars = {
     #Uncomment the following line for BYOL
     #local_sku	    = "${var.license1}"
-    host1	        = local.internal_bigips[0].subnets.0.private_ip
-    host2	        = local.internal_bigips[1].subnets.0.private_ip
-    local_host      = local.internal_bigips[1].subnets.0.private_dns_name
-    local_selfip    = local.internal_bigips[1].subnets.1.private_ip
-    local_selfip2   = local.internal_bigips[1].subnets.2.private_ip
-    local_selfip3   = local.internal_bigips[1].subnets.3.private_ip
-    remote_host	    = local.internal_bigips[0].subnets.0.private_dns_name
-    remote_selfip   = local.internal_bigips[0].subnets.2.private_ip
+    host1	        = local.internal_bigip_az1[0].subnets.0.private_ip
+    host2	        = local.internal_bigip_az2[0].subnets.0.private_ip
+    local_host      = local.internal_bigip_az2[0].subnets.0.private_dns_name
+    local_selfip    = local.internal_bigip_az2[0].subnets.1.private_ip
+    local_selfip2   = local.internal_bigip_az2[0].subnets.2.private_ip
+    local_selfip3   = local.internal_bigip_az2[0].subnets.3.private_ip
+    remote_host	    = local.internal_bigip_az1[0].subnets.0.private_dns_name
+    remote_selfip   = local.internal_bigip_az1[0].subnets.2.private_ip
     gateway	        = var.int1_gateway
     dns_server	    = var.dns_server
     ntp_server	    = var.ntp_server
@@ -240,28 +270,28 @@ provider "bigip" {
 
 provider "bigip" {
   alias = "ips_bigip_az1"
-  address = "https://${var.bigip_mgmt_ips.value.ips[0]}"
+  address = "https://${var.bigip_mgmt_ips.value.ips_az1[0]}"
   username = "admin"
   password = data.aws_secretsmanager_secret_version.secret.secret_string
 }
 
 provider "bigip" {
   alias = "ips_bigip_az2"
-  address = "https://${var.bigip_mgmt_ips.value.ips[1]}"
+  address = "https://${var.bigip_mgmt_ips.value.ips_az2[0]}"
   username = "admin"
   password = data.aws_secretsmanager_secret_version.secret.secret_string
 }
 
 provider "bigip" {
   alias = "internal_bigip_az1"
-  address = "https://${var.bigip_mgmt_ips.value.internal[0]}"
+  address = "https://${var.bigip_mgmt_ips.value.internal_az1[0]}"
   username = "admin"
   password = data.aws_secretsmanager_secret_version.secret.secret_string
 }
 
 provider "bigip" {
   alias = "internal_bigip_az2"
-  address = "https://${var.bigip_mgmt_ips.value.internal[1]}"
+  address = "https://${var.bigip_mgmt_ips.value.internal_az2[0]}"
   username = "admin"
   password = data.aws_secretsmanager_secret_version.secret.secret_string
 }

--- a/sca/configuration_stack/declarativeOnboarding.tf
+++ b/sca/configuration_stack/declarativeOnboarding.tf
@@ -138,8 +138,8 @@ data "template_file" "ips_bigip_az2_do_json" {
   vars = {
     #Uncomment the following line for BYOL
     #local_sku	    = "${var.license1}"
-    host1	        = local.ips_bigips[1].subnets.0.private_ip
-    host2	        = local.ips_bigips[0].subnets.0.private_ip
+    host1	        = local.ips_bigips[0].subnets.0.private_ip
+    host2	        = local.ips_bigips[1].subnets.0.private_ip
     local_host      = local.ips_bigips[1].subnets.0.private_dns_name
     local_selfip    = local.ips_bigips[1].subnets.1.private_ip
     local_selfip2   = local.ips_bigips[1].subnets.2.private_ip
@@ -238,6 +238,33 @@ provider "bigip" {
   password = data.aws_secretsmanager_secret_version.secret.secret_string
 }
 
+provider "bigip" {
+  alias = "ips_bigip_az1"
+  address = "https://${var.bigip_mgmt_ips.value.ips[0]}"
+  username = "admin"
+  password = data.aws_secretsmanager_secret_version.secret.secret_string
+}
+
+provider "bigip" {
+  alias = "ips_bigip_az2"
+  address = "https://${var.bigip_mgmt_ips.value.ips[1]}"
+  username = "admin"
+  password = data.aws_secretsmanager_secret_version.secret.secret_string
+}
+
+provider "bigip" {
+  alias = "internal_bigip_az1"
+  address = "https://${var.bigip_mgmt_ips.value.internal[0]}"
+  username = "admin"
+  password = data.aws_secretsmanager_secret_version.secret.secret_string
+}
+
+provider "bigip" {
+  alias = "internal_bigip_az2"
+  address = "https://${var.bigip_mgmt_ips.value.internal[1]}"
+  username = "admin"
+  password = data.aws_secretsmanager_secret_version.secret.secret_string
+}
 
 resource "bigip_do"  "external_bigip_az1" {
      provider = bigip.external_bigip_az1
@@ -245,12 +272,36 @@ resource "bigip_do"  "external_bigip_az1" {
      tenant_name = "external_bigip_az1"
  }
 
-
 resource "bigip_do"  "external_bigip_az2" {
      provider = bigip.external_bigip_az2
      do_json =  data.template_file.ext_bigip_az2_do_json.rendered
      tenant_name = "external_bigip_az2"
  }
+
+resource "bigip_do"  "ips_bigip_az1" {
+     provider = bigip.ips_bigip_az1
+     do_json =  data.template_file.ips_bigip_az1_do_json.rendered
+     tenant_name = "ips_bigip_az1"
+ }
+
+resource "bigip_do"  "ips_bigip_az2" {
+     provider = bigip.ips_bigip_az2
+     do_json =  data.template_file.ips_bigip_az2_do_json.rendered
+     tenant_name = "ips_bigip_az2"
+ }
+
+resource "bigip_do"  "internal_bigip_az1" {
+     provider = bigip.internal_bigip_az1
+     do_json =  data.template_file.internal_bigip_az1_do_json.rendered
+     tenant_name = "internal_bigip_az1"
+ }
+
+resource "bigip_do"  "internal_bigip_az2" {
+     provider = bigip.internal_bigip_az2
+     do_json =  data.template_file.internal_bigip_az2_do_json.rendered
+     tenant_name = "internal_bigip_az2"
+ }
+ 
 
 output external_bigips {
   value = var.bigip_mgmt_ips

--- a/sca/security_stack/internal.tf
+++ b/sca/security_stack/internal.tf
@@ -1,5 +1,5 @@
 locals {
-  internal_bigip_map = {
+  internal_bigip_map_az1 = {
     "0" = {
       "network_interfaces" = {
         "us-west-1a:management:0" = {
@@ -37,14 +37,18 @@ locals {
           "interface_type"    = "private"
           "private_ips_count" = 0
           "public_ip"         = false
-          "subnet_id"         = var.subnets.value.az1.security.peering
+          "subnet_id"         = var.subnets.value.az1.security.internal
           "subnet_security_group_ids" = [
             var.security_groups.value.private
           ]
         }
       }
     }
-    "1" = {
+  }
+}
+locals {
+    internal_bigip_map_az2 = {
+    "0" = {
       "network_interfaces" = {
         "us-west-1b:management:0" = {
           "device_index"      = "0"
@@ -81,7 +85,7 @@ locals {
           "interface_type"    = "private"
           "private_ips_count" = 0
           "public_ip"         = false
-          "subnet_id"         = var.subnets.value.az2.security.peering
+          "subnet_id"         = var.subnets.value.az2.security.internal
           "subnet_security_group_ids" = [
             var.security_groups.value.private
           ]
@@ -91,8 +95,8 @@ locals {
   }
 }
 # Setup Onboarding scripts
-data "template_file" "internal_onboard" {
-  template = "${file("${path.root}/templates/bigip_onboard_base.tmpl")}"
+data "template_file" "internal_onboard_az1" {
+  template = "${file("${path.root}/templates/bigip_onboard.tmpl")}"
 
   vars = {
     #uname        	      = var.adminAccountName
@@ -106,12 +110,73 @@ data "template_file" "internal_onboard" {
     fastVersion = var.atc_versions.fastVersion
     onboard_log = "/var/log/startup-script.log"
     secret_id   = var.secrets_manager_name.value
+    # gateways
+    applicationGateway =  var.aws_cidr_ips.value.az1.security.application_region
+    #dmzInsideGateway   =  var.aws_cidr_ips.value.az1.security.dmz_inside
+    dmzOutsideGateway  =  var.aws_cidr_ips.value.az1.security.internal
+    #egressCh1Gateway   =  var.aws_cidr_ips.value.az1.security.egress_to_ch1
+    #egressCh2Gateway   =  var.aws_cidr_ips.value.az1.security.egress_to_ch2
+    #internalGateway    =  var.aws_cidr_ips.value.az1.security.internal
+    externalGateway    =  var.aws_cidr_ips.value.az1.security.dmz_inside
+    #mgmtGateway        =  var.aws_cidr_ips.value.az1.security.mgmt
+    #peeringGateway     =  var.aws_cidr_ips.value.az1.security.peering
+    # networks
+    applicationNetwork =  var.subnet_cidrs.value.az1.security.application_region
+    #dmzInsideNetwork   =  var.subnet_cidrs.value.az1.security.dmz_inside
+    dmzOutsideNetwork  =  var.subnet_cidrs.value.az1.security.internal
+    #egressCh1Network   =  var.subnet_cidrs.value.az1.security.egress_to_ch1
+    #egressCh2Network   =  var.subnet_cidrs.value.az1.security.egress_to_ch2
+    #internalNetwork    =  var.subnet_cidrs.value.az1.security.internal
+    externalNetwork    =  var.subnet_cidrs.value.az1.security.dmz_inside
+    #mgmtNetwork        =  var.subnet_cidrs.value.az1.security.mgmt
+    #peeringNetwork     =  var.subnet_cidrs.value.az1.security.peering
+    # sync must be other az
+    syncNetwork        = var.subnet_cidrs.value.az2.security.application_region
+  }
+}
+data "template_file" "internal_onboard_az2" {
+  template = "${file("${path.root}/templates/bigip_onboard.tmpl")}"
+
+  vars = {
+    #uname        	      = var.adminAccountName
+    # atc versions
+    #example version:
+    #as3Version            = "3.16.0"
+    doVersion   = var.atc_versions.doVersion
+    as3Version  = var.atc_versions.as3Version
+    tsVersion   = var.atc_versions.tsVersion
+    cfVersion   = var.atc_versions.cfVersion
+    fastVersion = var.atc_versions.fastVersion
+    onboard_log = "/var/log/startup-script.log"
+    secret_id   = var.secrets_manager_name.value
+    # gateways
+    applicationGateway =  var.aws_cidr_ips.value.az2.security.application_region
+    #dmzInsideGateway   =  var.aws_cidr_ips.value.az2.security.dmz_inside
+    dmzOutsideGateway  =  var.aws_cidr_ips.value.az2.security.internal
+    #egressCh1Gateway   =  var.aws_cidr_ips.value.az2.security.egress_to_ch1
+    #egressCh2Gateway   =  var.aws_cidr_ips.value.az2.security.egress_to_ch2
+    #internalGateway    =  var.aws_cidr_ips.value.az2.security.internal
+    externalGateway    =  var.aws_cidr_ips.value.az2.security.dmz_inside
+    #mgmtGateway        =  var.aws_cidr_ips.value.az2.security.mgmt
+    #peeringGateway     =  var.aws_cidr_ips.value.az2.security.peering
+    # networks
+    applicationNetwork =  var.subnet_cidrs.value.az2.security.application_region
+    #dmzInsideNetwork   =  var.subnet_cidrs.value.az2.security.dmz_inside
+    dmzOutsideNetwork  =  var.subnet_cidrs.value.az2.security.internal
+    #egressCh1Network   =  var.subnet_cidrs.value.az2.security.egress_to_ch1
+    #egressCh2Network   =  var.subnet_cidrs.value.az2.security.egress_to_ch2
+    #internalNetwork    =  var.subnet_cidrs.value.az2.security.internal
+    externalNetwork    =  var.subnet_cidrs.value.az2.security.dmz_inside
+    #mgmtNetwork        =  var.subnet_cidrs.value.az2.security.mgmt
+    #peeringNetwork     =  var.subnet_cidrs.value.az2.security.peering
+    # sync must be other az
+    syncNetwork        = var.subnet_cidrs.value.az1.security.application_region
   }
 }
 #
 # Create BIG-IP
 #
-module internal {
+module internal_az1 {
   source = "github.com/f5devcentral/terraform-aws-bigip?ref=develop"
 
   prefix = format(
@@ -122,7 +187,23 @@ module internal {
   ec2_instance_type           = var.ec2_instance_type
   ec2_key_name                = var.ec2_key_name
   aws_secretmanager_secret_id = var.secrets_manager_name.value
-  bigip_map                   = local.internal_bigip_map
+  bigip_map                   = local.internal_bigip_map_az1
   iam_instance_profile        = var.iam_instance_profile_name.value
-  custom_user_data            = data.template_file.internal_onboard.rendered
+  custom_user_data            = data.template_file.internal_onboard_az1.rendered
+}
+
+module internal_az2 {
+  source = "github.com/f5devcentral/terraform-aws-bigip?ref=develop"
+
+  prefix = format(
+    "%s-bigip_with_new_vpc_internal-%s",
+    var.project.value,
+    var.random_id.value
+  )
+  ec2_instance_type           = var.ec2_instance_type
+  ec2_key_name                = var.ec2_key_name
+  aws_secretmanager_secret_id = var.secrets_manager_name.value
+  bigip_map                   = local.internal_bigip_map_az2
+  iam_instance_profile        = var.iam_instance_profile_name.value
+  custom_user_data            = data.template_file.internal_onboard_az2.rendered
 }

--- a/sca/security_stack/internal.tf
+++ b/sca/security_stack/internal.tf
@@ -115,7 +115,7 @@ module internal {
   source = "github.com/f5devcentral/terraform-aws-bigip?ref=develop"
 
   prefix = format(
-    "%s-bigip_with_new_vpc-%s",
+    "%s-bigip_with_new_vpc_internal-%s",
     var.project.value,
     var.random_id.value
   )

--- a/sca/security_stack/ips.tf
+++ b/sca/security_stack/ips.tf
@@ -115,7 +115,7 @@ module ips {
   source = "github.com/f5devcentral/terraform-aws-bigip?ref=develop"
 
   prefix = format(
-    "%s-bigip_with_new_vpc-%s",
+    "%s-bigip_with_new_vpc_ips-%s",
     var.project.value,
     var.random_id.value
   )

--- a/sca/security_stack/ips.tf
+++ b/sca/security_stack/ips.tf
@@ -1,5 +1,5 @@
 locals {
-  ips_bigip_map = {
+  ips_bigip_map_az1 = {
     "0" = {
       "network_interfaces" = {
         "us-west-1a:management:0" = {
@@ -44,7 +44,11 @@ locals {
         }
       }
     }
-    "1" = {
+  }
+}
+locals {
+  ips_bigip_map_az2 = {
+    "0" = {
       "network_interfaces" = {
         "us-west-1b:management:0" = {
           "device_index"      = "0"
@@ -91,8 +95,8 @@ locals {
   }
 }
 # Setup Onboarding scripts
-data "template_file" "ips_onboard" {
-  template = "${file("${path.root}/templates/bigip_onboard_base.tmpl")}"
+data "template_file" "ips_onboard_az1" {
+  template = "${file("${path.root}/templates/bigip_onboard.tmpl")}"
 
   vars = {
     #uname        	      = var.adminAccountName
@@ -106,12 +110,73 @@ data "template_file" "ips_onboard" {
     fastVersion = var.atc_versions.fastVersion
     onboard_log = "/var/log/startup-script.log"
     secret_id   = var.secrets_manager_name.value
+    # gateways
+    applicationGateway =  var.aws_cidr_ips.value.az1.security.application_region
+    #dmzInsideGateway   =  var.aws_cidr_ips.value.az1.security.dmz_inside
+    dmzOutsideGateway  =  var.aws_cidr_ips.value.az1.security.dmz_inside
+    #egressCh1Gateway   =  var.aws_cidr_ips.value.az1.security.egress_to_ch1
+    #egressCh2Gateway   =  var.aws_cidr_ips.value.az1.security.egress_to_ch2
+    #internalGateway    =  var.aws_cidr_ips.value.az1.security.internal
+    externalGateway    =  var.aws_cidr_ips.value.az1.security.dmz_outside
+    #mgmtGateway        =  var.aws_cidr_ips.value.az1.security.mgmt
+    #peeringGateway     =  var.aws_cidr_ips.value.az1.security.peering
+    # networks
+    applicationNetwork =  var.subnet_cidrs.value.az1.security.application_region
+    #dmzInsideNetwork   =  var.subnet_cidrs.value.az1.security.dmz_inside
+    dmzOutsideNetwork  =  var.subnet_cidrs.value.az1.security.dmz_inside
+    #egressCh1Network   =  var.subnet_cidrs.value.az1.security.egress_to_ch1
+    #egressCh2Network   =  var.subnet_cidrs.value.az1.security.egress_to_ch2
+    #internalNetwork    =  var.subnet_cidrs.value.az1.security.internal
+    externalNetwork    =  var.subnet_cidrs.value.az1.security.dmz_outside
+    #mgmtNetwork        =  var.subnet_cidrs.value.az1.security.mgmt
+    #peeringNetwork     =  var.subnet_cidrs.value.az1.security.peering
+    # sync must be other az
+    syncNetwork        = var.subnet_cidrs.value.az2.security.application_region
+  }
+}
+data "template_file" "ips_onboard_az2" {
+  template = "${file("${path.root}/templates/bigip_onboard.tmpl")}"
+
+  vars = {
+    #uname        	      = var.adminAccountName
+    # atc versions
+    #example version:
+    #as3Version            = "3.16.0"
+    doVersion   = var.atc_versions.doVersion
+    as3Version  = var.atc_versions.as3Version
+    tsVersion   = var.atc_versions.tsVersion
+    cfVersion   = var.atc_versions.cfVersion
+    fastVersion = var.atc_versions.fastVersion
+    onboard_log = "/var/log/startup-script.log"
+    secret_id   = var.secrets_manager_name.value
+    # gateways
+    applicationGateway =  var.aws_cidr_ips.value.az2.security.application_region
+    #dmzInsideGateway   =  var.aws_cidr_ips.value.az2.security.dmz_inside
+    dmzOutsideGateway  =  var.aws_cidr_ips.value.az2.security.dmz_inside
+    #egressCh1Gateway   =  var.aws_cidr_ips.value.az2.security.egress_to_ch1
+    #egressCh2Gateway   =  var.aws_cidr_ips.value.az2.security.egress_to_ch2
+    #internalGateway    =  var.aws_cidr_ips.value.az2.security.internal
+    externalGateway    =  var.aws_cidr_ips.value.az2.security.dmz_outside
+    #mgmtGateway        =  var.aws_cidr_ips.value.az2.security.mgmt
+    #peeringGateway     =  var.aws_cidr_ips.value.az2.security.peering
+    # networks
+    applicationNetwork =  var.subnet_cidrs.value.az2.security.application_region
+    #dmzInsideNetwork   =  var.subnet_cidrs.value.az2.security.dmz_inside
+    dmzOutsideNetwork  =  var.subnet_cidrs.value.az2.security.dmz_inside
+    #egressCh1Network   =  var.subnet_cidrs.value.az2.security.egress_to_ch1
+    #egressCh2Network   =  var.subnet_cidrs.value.az2.security.egress_to_ch2
+    #internalNetwork    =  var.subnet_cidrs.value.az2.security.internal
+    externalNetwork    =  var.subnet_cidrs.value.az2.security.dmz_outside
+    #mgmtNetwork        =  var.subnet_cidrs.value.az2.security.mgmt
+    #peeringNetwork     =  var.subnet_cidrs.value.az2.security.peering
+    # sync must be other az
+    syncNetwork        = var.subnet_cidrs.value.az1.security.application_region
   }
 }
 #
 # Create BIG-IP
 #
-module ips {
+module ips_az1 {
   source = "github.com/f5devcentral/terraform-aws-bigip?ref=develop"
 
   prefix = format(
@@ -122,7 +187,22 @@ module ips {
   ec2_instance_type           = var.ec2_instance_type
   ec2_key_name                = var.ec2_key_name
   aws_secretmanager_secret_id = var.secrets_manager_name.value
-  bigip_map                   = local.ips_bigip_map
+  bigip_map                   = local.ips_bigip_map_az1
   iam_instance_profile        = var.iam_instance_profile_name.value
-  custom_user_data            = data.template_file.ips_onboard.rendered
+  custom_user_data            = data.template_file.ips_onboard_az1.rendered
+}
+module ips_az2 {
+  source = "github.com/f5devcentral/terraform-aws-bigip?ref=develop"
+
+  prefix = format(
+    "%s-bigip_with_new_vpc_ips-%s",
+    var.project.value,
+    var.random_id.value
+  )
+  ec2_instance_type           = var.ec2_instance_type
+  ec2_key_name                = var.ec2_key_name
+  aws_secretmanager_secret_id = var.secrets_manager_name.value
+  bigip_map                   = local.ips_bigip_map_az2
+  iam_instance_profile        = var.iam_instance_profile_name.value
+  custom_user_data            = data.template_file.ips_onboard_az2.rendered
 }

--- a/sca/security_stack/output.tf
+++ b/sca/security_stack/output.tf
@@ -3,8 +3,10 @@ output "bigip_mgmt_ips" {
   value = {
     external_az1 = module.external_az1.mgmt_public_ips
     external_az2 = module.external_az2.mgmt_public_ips
-    ips      = module.ips.mgmt_public_ips
-    internal = module.internal.mgmt_public_ips
+    ips_az1      = module.ips_az1.mgmt_public_ips
+    ips_az2      = module.ips_az2.mgmt_public_ips
+    internal_az1 = module.internal_az1.mgmt_public_ips
+    internal_az2 = module.internal_az2.mgmt_public_ips
   }
 }
 
@@ -13,8 +15,10 @@ output "bigip_mgmt_dns" {
   value = {
     external_az1 = module.external_az1.mgmt_public_dns
     external_az2 = module.external_az2.mgmt_public_dns
-    ips      = module.ips.mgmt_public_dns
-    internal = module.internal.mgmt_public_dns
+    ips_az1      = module.ips_az1.mgmt_public_dns
+    ips_az2      = module.ips_az2.mgmt_public_dns
+    internal_az1 = module.internal_az1.mgmt_public_dns
+    internal_az2 = module.internal_az2.mgmt_public_dns
   }
 }
 
@@ -23,8 +27,10 @@ output "bigip_mgmt_port" {
   value = {
     external_az1 = module.external_az1.mgmt_port
     external_az2 = module.external_az2.mgmt_port
-    ips      = module.ips.mgmt_port
-    internal = module.internal.mgmt_port
+    ips_az1      = module.ips_az1.mgmt_port
+    ips_az2      = module.ips_az2.mgmt_port
+    internal_az1 = module.internal_az1.mgmt_port
+    internal_az2 = module.internal_az2.mgmt_port
   }
 }
 
@@ -33,8 +39,10 @@ output "mgmt_addresses" {
   value = {
     external_az1 = module.external_az1.mgmt_addresses
     external_az2 = module.external_az2.mgmt_addresses
-    ips      = module.ips.mgmt_addresses
-    internal = module.internal.mgmt_addresses
+    ips_az1      = module.ips_az1.mgmt_addresses
+    ips_az2      = module.ips_az2.mgmt_addresses
+    internal_az1 = module.internal_az1.mgmt_addresses
+    internal_az2 = module.internal_az2.mgmt_addresses
   }
 }
 
@@ -43,8 +51,10 @@ output "public_addresses" {
   value = {
     external_az1 = module.external_az1.public_addresses
     external_az2 = module.external_az2.public_addresses
-    ips      = module.ips.public_addresses
-    internal = module.internal.public_addresses
+    ips_az1      = module.ips_az1.public_addresses
+    ips_az2      = module.ips_az2.public_addresses
+    internal_az1 = module.internal_az1.public_addresses
+    internal_az2 = module.internal_az2.public_addresses
   }
 }
 
@@ -53,8 +63,10 @@ output "private_addresses" {
   value = {
     external_az1 = module.external_az1.private_addresses
     external_az2 = module.external_az2.private_addresses
-    ips      = module.ips.private_addresses
-    internal = module.internal.private_addresses
+    ips_az1      = module.ips_az1.private_addresses
+    ips_az2      = module.ips_az2.private_addresses
+    internal_az1 = module.internal_az1.private_addresses
+    internal_az2 = module.internal_az2.private_addresses
   }
 }
 
@@ -64,8 +76,10 @@ output "public_nic_ids" {
   value = {
     external_az1 = module.external_az1.public_nic_ids
     external_az2 = module.external_az2.public_nic_ids
-    ips      = module.ips.public_nic_ids
-    internal = module.internal.public_nic_ids
+    ips_az1      = module.ips_az1.public_nic_ids
+    ips_az2      = module.ips_az2.public_nic_ids
+    internal_az1 = module.internal_az1.public_nic_ids
+    internal_az2 = module.internal_az2.public_nic_ids
   }
 }
 
@@ -75,7 +89,9 @@ output "bigip_map" {
   value = {
     external_az1 = module.external_az1.bigip_map
     external_az2 = module.external_az2.bigip_map
-    ips      = module.ips.bigip_map
-    internal = module.internal.bigip_map
+    ips_az1      = module.ips_az1.bigip_map
+    ips_az2      = module.ips_az2.bigip_map
+    internal_az1 = module.internal_az1.bigip_map
+    internal_az2 = module.internal_az2.bigip_map
   }
 }


### PR DESCRIPTION
This PR completes the following
- [AB#40124](https://dev.azure.com/f5eng/1969f822-cce2-4965-baeb-b0253d28034f/_workitems/edit/40124) (IPS and Internal tiers now clustered by DO)
- [AB#48648](https://dev.azure.com/f5eng/1969f822-cce2-4965-baeb-b0253d28034f/_workitems/edit/48648) (Internal tier was connected to wrong subnet)
- [AB#48692](https://dev.azure.com/f5eng/1969f822-cce2-4965-baeb-b0253d28034f/_workitems/edit/48692) (IPS tier had conflicting DO declarations)
