### PR TITLE
Work moleary cfe

### DIFF
--- a/sca/configuration_stack/as3declaration.tf
+++ b/sca/configuration_stack/as3declaration.tf
@@ -52,6 +52,7 @@ resource "bigip_as3"  "external_bigip_az1" {
       virtualAddress = "0.0.0.0/0",
       allowedVlan = "internal"
     })
+    tenant_name = "baseline"
  }
 
  resource "bigip_as3"  "internal_bigip_az1" {
@@ -64,4 +65,5 @@ resource "bigip_as3"  "external_bigip_az1" {
       virtualAddress = "0.0.0.0/0",
       allowedVlan = "internal"
     })
+    tenant_name = "baseline"
  }

--- a/sca/configuration_stack/as3declaration.tf
+++ b/sca/configuration_stack/as3declaration.tf
@@ -7,11 +7,7 @@ data "template_file" "as3_declaration_baseline" {
   }
 }
 
-resource "local_file" "as3_declaration_baseline" {
-  content     = data.template_file.as3_declaration_baseline.rendered
-  filename    = "${path.module}/as3_declaration_baseline.json"
-}
-
+/*
 resource "null_resource" "as3-external" {
   depends_on = [
     null_resource.cfe-external-az1,
@@ -45,26 +41,27 @@ resource "null_resource" "as3-internal" {
     EOF
   }
 }
-/*
+ */
 resource "bigip_as3"  "external_bigip_az1" {
      depends_on = [
-        local_file.as3_declaration_baseline,
         null_resource.cfe-internal-az1,
         null_resource.cfe-internal-az2
      ]
      provider = bigip.external_bigip_az1
-     as3_json =  file("./as3_declaration_baseline.json")
-     tenant_filter = "baseline"
+     as3_json =  templatefile("${path.module}/templates/as3/as3.tmpl", {
+      virtualAddress = "0.0.0.0/0",
+      allowedVlan = "internal"
+    })
  }
 
  resource "bigip_as3"  "internal_bigip_az1" {
      depends_on = [
-        local_file.as3_declaration_baseline,
         null_resource.cfe-internal-az1,
         null_resource.cfe-internal-az2
      ]
      provider = bigip.internal_bigip_az1
-     as3_json =  file("./as3_declaration_baseline.json")
-     tenant_filter = "baseline"
+     as3_json =  templatefile("${path.module}/templates/as3/as3.tmpl", {
+      virtualAddress = "0.0.0.0/0",
+      allowedVlan = "internal"
+    })
  }
- */

--- a/sca/configuration_stack/as3declaration.tf
+++ b/sca/configuration_stack/as3declaration.tf
@@ -1,0 +1,70 @@
+data "template_file" "as3_declaration_baseline" {
+  template = file("${path.module}/templates/as3/as3.tmpl")
+
+  vars = {
+    virtualAddress	        = "0.0.0.0/0"
+    allowedVlan	        = "internal"
+  }
+}
+
+resource "local_file" "as3_declaration_baseline" {
+  content     = data.template_file.as3_declaration_baseline.rendered
+  filename    = "${path.module}/as3_declaration_baseline.json"
+}
+
+resource "null_resource" "as3-external" {
+  depends_on = [
+    null_resource.cfe-external-az1,
+    null_resource.cfe-external-az2
+    ]
+  # Running CFE REST API
+  provisioner "local-exec" {
+    command = <<-EOF
+      #!/bin/bash
+      sleep 15
+      curl -k -X GET https://${var.bigip_mgmt_ips.value.external_az1[0]}/mgmt/shared/appsvcs/declare -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string}
+      sleep 10
+      curl -k -X POST https://${var.bigip_mgmt_ips.value.external_az1[0]}/mgmt/shared/appsvcs/declare -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string} -d @${path.module}/as3_declaration_baseline.json
+    EOF
+  }
+}
+
+resource "null_resource" "as3-internal" {
+  depends_on = [
+    null_resource.cfe-internal-az1,
+    null_resource.cfe-internal-az2
+    ]
+  # Running CFE REST API
+  provisioner "local-exec" {
+    command = <<-EOF
+      #!/bin/bash
+      sleep 15
+      curl -k -X GET https://${var.bigip_mgmt_ips.value.internal_az1[0]}/mgmt/shared/appsvcs/declare -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string}
+      sleep 10
+      curl -k -X POST https://${var.bigip_mgmt_ips.value.internal_az1[0]}/mgmt/shared/appsvcs/declare -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string} -d @${path.module}/as3_declaration_baseline.json
+    EOF
+  }
+}
+/*
+resource "bigip_as3"  "external_bigip_az1" {
+     depends_on = [
+        local_file.as3_declaration_baseline,
+        null_resource.cfe-internal-az1,
+        null_resource.cfe-internal-az2
+     ]
+     provider = bigip.external_bigip_az1
+     as3_json =  file("./as3_declaration_baseline.json")
+     tenant_filter = "baseline"
+ }
+
+ resource "bigip_as3"  "internal_bigip_az1" {
+     depends_on = [
+        local_file.as3_declaration_baseline,
+        null_resource.cfe-internal-az1,
+        null_resource.cfe-internal-az2
+     ]
+     provider = bigip.internal_bigip_az1
+     as3_json =  file("./as3_declaration_baseline.json")
+     tenant_filter = "baseline"
+ }
+ */

--- a/sca/configuration_stack/as3declaration.tf
+++ b/sca/configuration_stack/as3declaration.tf
@@ -7,43 +7,10 @@ data "template_file" "as3_declaration_baseline" {
   }
 }
 
-/*
-resource "null_resource" "as3-external" {
-  depends_on = [
-    null_resource.cfe-external-az1,
-    null_resource.cfe-external-az2
-    ]
-  # Running CFE REST API
-  provisioner "local-exec" {
-    command = <<-EOF
-      #!/bin/bash
-      sleep 15
-      curl -k -X GET https://${var.bigip_mgmt_ips.value.external_az1[0]}/mgmt/shared/appsvcs/declare -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string}
-      sleep 10
-      curl -k -X POST https://${var.bigip_mgmt_ips.value.external_az1[0]}/mgmt/shared/appsvcs/declare -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string} -d @${path.module}/as3_declaration_baseline.json
-    EOF
-  }
-}
-
-resource "null_resource" "as3-internal" {
-  depends_on = [
-    null_resource.cfe-internal-az1,
-    null_resource.cfe-internal-az2
-    ]
-  # Running CFE REST API
-  provisioner "local-exec" {
-    command = <<-EOF
-      #!/bin/bash
-      sleep 15
-      curl -k -X GET https://${var.bigip_mgmt_ips.value.internal_az1[0]}/mgmt/shared/appsvcs/declare -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string}
-      sleep 10
-      curl -k -X POST https://${var.bigip_mgmt_ips.value.internal_az1[0]}/mgmt/shared/appsvcs/declare -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string} -d @${path.module}/as3_declaration_baseline.json
-    EOF
-  }
-}
- */
 resource "bigip_as3"  "external_bigip_az1" {
      depends_on = [
+        bigip_do.external_bigip_az1,
+        bigip_do.external_bigip_az2,
         null_resource.cfe-internal-az1,
         null_resource.cfe-internal-az2
      ]
@@ -52,11 +19,12 @@ resource "bigip_as3"  "external_bigip_az1" {
       virtualAddress = "0.0.0.0/0",
       allowedVlan = "internal"
     })
-    tenant_name = "baseline"
  }
 
  resource "bigip_as3"  "internal_bigip_az1" {
      depends_on = [
+        bigip_do.internal_bigip_az1,
+        bigip_do.internal_bigip_az2,
         null_resource.cfe-internal-az1,
         null_resource.cfe-internal-az2
      ]
@@ -65,5 +33,4 @@ resource "bigip_as3"  "external_bigip_az1" {
       virtualAddress = "0.0.0.0/0",
       allowedVlan = "internal"
     })
-    tenant_name = "baseline"
  }

--- a/sca/configuration_stack/cloudFailoverExtension.tf
+++ b/sca/configuration_stack/cloudFailoverExtension.tf
@@ -84,8 +84,8 @@ resource "local_file" "int_cfe_json" {
 
 resource "null_resource" "cfe-external-az1" {
   depends_on = [
-    "bigip_do.external_bigip_az1",
-    "bigip_do.external_bigip_az2"
+    bigip_do.external_bigip_az1,
+    bigip_do.external_bigip_az2
     ]
   # Running CFE REST API
   provisioner "local-exec" {
@@ -101,8 +101,8 @@ resource "null_resource" "cfe-external-az1" {
 
 resource "null_resource" "cfe-external-az2" {
   depends_on = [
-    "bigip_do.external_bigip_az1",
-    "bigip_do.external_bigip_az2"
+    bigip_do.external_bigip_az1,
+    bigip_do.external_bigip_az2
     ]
   # Running CFE REST API
   provisioner "local-exec" {
@@ -118,8 +118,8 @@ resource "null_resource" "cfe-external-az2" {
 
 resource "null_resource" "cfe-internal-az1" {
   depends_on = [
-    "bigip_do.internal_bigip_az1",
-    "bigip_do.internal_bigip_az2"
+    bigip_do.internal_bigip_az1,
+    bigip_do.internal_bigip_az2
     ]
   # Running CFE REST API
   provisioner "local-exec" {
@@ -129,14 +129,15 @@ resource "null_resource" "cfe-internal-az1" {
       curl -k -X GET https://${var.bigip_mgmt_ips.value.internal_az1[0]}/mgmt/shared/cloud-failover/info -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string}
       sleep 10
       curl -k -X POST https://${var.bigip_mgmt_ips.value.internal_az1[0]}/mgmt/shared/cloud-failover/declare -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string} -d @${path.module}/int_cfe_json.json
+      sleep 25
     EOF
   }
 }
 
 resource "null_resource" "cfe-internal-az2" {
   depends_on = [
-    "bigip_do.internal_bigip_az1",
-    "bigip_do.internal_bigip_az2"
+    bigip_do.internal_bigip_az1,
+    bigip_do.internal_bigip_az2
     ]
   # Running CFE REST API
   provisioner "local-exec" {
@@ -146,6 +147,7 @@ resource "null_resource" "cfe-internal-az2" {
       curl -k -X GET https://${var.bigip_mgmt_ips.value.internal_az2[0]}/mgmt/shared/cloud-failover/info -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string}
       sleep 10
       curl -k -X POST https://${var.bigip_mgmt_ips.value.internal_az2[0]}/mgmt/shared/cloud-failover/declare -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string} -d @${path.module}/int_cfe_json.json
+      sleep 25
     EOF
   }
 }

--- a/sca/configuration_stack/cloudFailoverExtension.tf
+++ b/sca/configuration_stack/cloudFailoverExtension.tf
@@ -1,0 +1,151 @@
+locals {
+  ext_self_ip_extNic_az1 = flatten([
+    for environment, bigips in var.bigip_map.value : [
+      for key, bigip in bigips : {
+        id : key
+        subnets : {
+          for subnet, data in bigip : data.attachment[0].device_index => {
+            private_ip : data.private_ip
+          }
+        }
+      }
+    ] if(environment == "external_az1")
+  ])
+  ext_self_ip_extNic_az2 = flatten([
+    for environment, bigips in var.bigip_map.value : [
+      for key, bigip in bigips : {
+        id : key
+        subnets : {
+          for subnet, data in bigip : data.attachment[0].device_index => {
+            private_ip : data.private_ip
+          }
+        }
+      }
+    ] if(environment == "external_az2")
+  ])
+  int_self_ip_intNic_az1 = flatten([
+    for environment, bigips in var.bigip_map.value : [
+      for key, bigip in bigips : {
+        id : key
+        subnets : {
+          for subnet, data in bigip : data.attachment[0].device_index => {
+            private_ip : data.private_ip
+          }
+        }
+      }
+    ] if(environment == "internal_az1")
+  ])
+  int_self_ip_intNic_az2 = flatten([
+    for environment, bigips in var.bigip_map.value : [
+      for key, bigip in bigips : {
+        id : key
+        subnets : {
+          for subnet, data in bigip : data.attachment[0].device_index => {
+            private_ip : data.private_ip
+          }
+        }
+      }
+    ] if(environment == "internal_az2")
+  ])
+}
+
+# Template files for CFE declarations
+data "template_file" "cfe_declaration_ext_tier" {
+  template = file("${path.module}/templates/cloudFailoverExtension/cfe.json")
+
+  vars = {
+    label	        = var.cfe_bucket_external.value.tags.f5_cloud_failover_label
+    labelRouteTable = var.CFE_route_tables.value.internet
+    range         = "192.168.100.0/24"
+    local_selfip    = local.ext_self_ip_extNic_az1[0].subnets[1].private_ip
+    remote_selfip    = local.ext_self_ip_extNic_az2[0].subnets[1].private_ip
+  }
+}
+data "template_file" "cfe_declaration_int_tier" {
+  template = file("${path.module}/templates/cloudFailoverExtension/cfe.json")
+
+  vars = {
+    label	        = var.cfe_bucket_internal.value.tags.f5_cloud_failover_label
+    labelRouteTable = var.CFE_route_tables.value.internal
+    range         = "0.0.0.0/0"
+    local_selfip    = local.int_self_ip_intNic_az1[0].subnets[3].private_ip
+    remote_selfip    = local.int_self_ip_intNic_az2[0].subnets[3].private_ip
+  }
+}
+
+resource "local_file" "ext_cfe_json" {
+  content     = data.template_file.cfe_declaration_ext_tier.rendered
+  filename    = "${path.module}/ext_cfe_json.json"
+}
+resource "local_file" "int_cfe_json" {
+  content     = data.template_file.cfe_declaration_int_tier.rendered
+  filename    = "${path.module}/int_cfe_json.json"
+}
+
+resource "null_resource" "cfe-external-az1" {
+  depends_on = [
+    "bigip_do.external_bigip_az1",
+    "bigip_do.external_bigip_az2"
+    ]
+  # Running CFE REST API
+  provisioner "local-exec" {
+    command = <<-EOF
+      #!/bin/bash
+      sleep 15
+      curl -k -X GET https://${var.bigip_mgmt_ips.value.external_az1[0]}/mgmt/shared/cloud-failover/info -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string}
+      sleep 10
+      curl -k -X POST https://${var.bigip_mgmt_ips.value.external_az1[0]}/mgmt/shared/cloud-failover/declare -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string} -d @${path.module}/ext_cfe_json.json
+    EOF
+  }
+}
+
+resource "null_resource" "cfe-external-az2" {
+  depends_on = [
+    "bigip_do.external_bigip_az1",
+    "bigip_do.external_bigip_az2"
+    ]
+  # Running CFE REST API
+  provisioner "local-exec" {
+    command = <<-EOF
+      #!/bin/bash
+      sleep 15
+      curl -k -X GET https://${var.bigip_mgmt_ips.value.external_az2[0]}/mgmt/shared/cloud-failover/info -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string}
+      sleep 10
+      curl -k -X POST https://${var.bigip_mgmt_ips.value.external_az2[0]}/mgmt/shared/cloud-failover/declare -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string} -d @${path.module}/ext_cfe_json.json
+    EOF
+  }
+}
+
+resource "null_resource" "cfe-internal-az1" {
+  depends_on = [
+    "bigip_do.internal_bigip_az1",
+    "bigip_do.internal_bigip_az2"
+    ]
+  # Running CFE REST API
+  provisioner "local-exec" {
+    command = <<-EOF
+      #!/bin/bash
+      sleep 15
+      curl -k -X GET https://${var.bigip_mgmt_ips.value.internal_az1[0]}/mgmt/shared/cloud-failover/info -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string}
+      sleep 10
+      curl -k -X POST https://${var.bigip_mgmt_ips.value.internal_az1[0]}/mgmt/shared/cloud-failover/declare -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string} -d @${path.module}/int_cfe_json.json
+    EOF
+  }
+}
+
+resource "null_resource" "cfe-internal-az2" {
+  depends_on = [
+    "bigip_do.internal_bigip_az1",
+    "bigip_do.internal_bigip_az2"
+    ]
+  # Running CFE REST API
+  provisioner "local-exec" {
+    command = <<-EOF
+      #!/bin/bash
+      sleep 15
+      curl -k -X GET https://${var.bigip_mgmt_ips.value.internal_az2[0]}/mgmt/shared/cloud-failover/info -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string}
+      sleep 10
+      curl -k -X POST https://${var.bigip_mgmt_ips.value.internal_az2[0]}/mgmt/shared/cloud-failover/declare -u admin:${data.aws_secretsmanager_secret_version.secret.secret_string} -d @${path.module}/int_cfe_json.json
+    EOF
+  }
+}

--- a/sca/configuration_stack/declarativeOnboarding.tf
+++ b/sca/configuration_stack/declarativeOnboarding.tf
@@ -233,31 +233,37 @@ data "template_file" "internal_bigip_az2_do_json" {
 resource "bigip_do"  "external_bigip_az1" {
      provider = bigip.external_bigip_az1
      do_json =  data.template_file.ext_bigip_az1_do_json.rendered
+     tenant_name = "baseline"
  }
 
 resource "bigip_do"  "external_bigip_az2" {
      provider = bigip.external_bigip_az2
      do_json =  data.template_file.ext_bigip_az2_do_json.rendered
+     tenant_name = "baseline"
  }
 
 resource "bigip_do"  "ips_bigip_az1" {
      provider = bigip.ips_bigip_az1
      do_json =  data.template_file.ips_bigip_az1_do_json.rendered
+     tenant_name = "baseline"
  }
 
 resource "bigip_do"  "ips_bigip_az2" {
      provider = bigip.ips_bigip_az2
      do_json =  data.template_file.ips_bigip_az2_do_json.rendered
+     tenant_name = "baseline"
  }
 
 resource "bigip_do"  "internal_bigip_az1" {
      provider = bigip.internal_bigip_az1
      do_json =  data.template_file.internal_bigip_az1_do_json.rendered
+     tenant_name = "baseline"
  }
 
 resource "bigip_do"  "internal_bigip_az2" {
      provider = bigip.internal_bigip_az2
      do_json =  data.template_file.internal_bigip_az2_do_json.rendered
+     tenant_name = "baseline"
  }
  
 

--- a/sca/configuration_stack/declarativeOnboarding.tf
+++ b/sca/configuration_stack/declarativeOnboarding.tf
@@ -233,37 +233,37 @@ data "template_file" "internal_bigip_az2_do_json" {
 resource "bigip_do"  "external_bigip_az1" {
      provider = bigip.external_bigip_az1
      do_json =  data.template_file.ext_bigip_az1_do_json.rendered
-     tenant_name = "baseline"
+     #tenant_name = "baseline"
  }
 
 resource "bigip_do"  "external_bigip_az2" {
      provider = bigip.external_bigip_az2
      do_json =  data.template_file.ext_bigip_az2_do_json.rendered
-     tenant_name = "baseline"
+     #tenant_name = "baseline"
  }
 
 resource "bigip_do"  "ips_bigip_az1" {
      provider = bigip.ips_bigip_az1
      do_json =  data.template_file.ips_bigip_az1_do_json.rendered
-     tenant_name = "baseline"
+     #tenant_name = "baseline"
  }
 
 resource "bigip_do"  "ips_bigip_az2" {
      provider = bigip.ips_bigip_az2
      do_json =  data.template_file.ips_bigip_az2_do_json.rendered
-     tenant_name = "baseline"
+     #tenant_name = "baseline"
  }
 
 resource "bigip_do"  "internal_bigip_az1" {
      provider = bigip.internal_bigip_az1
      do_json =  data.template_file.internal_bigip_az1_do_json.rendered
-     tenant_name = "baseline"
+     #tenant_name = "baseline"
  }
 
 resource "bigip_do"  "internal_bigip_az2" {
      provider = bigip.internal_bigip_az2
      do_json =  data.template_file.internal_bigip_az2_do_json.rendered
-     tenant_name = "baseline"
+     #tenant_name = "baseline"
  }
  
 

--- a/sca/configuration_stack/declarativeOnboarding.tf
+++ b/sca/configuration_stack/declarativeOnboarding.tf
@@ -229,107 +229,35 @@ data "template_file" "internal_bigip_az2_do_json" {
     admin_password  = data.aws_secretsmanager_secret_version.secret.secret_string
   }
 }
-resource "local_file" "ext_bigip_az1_do_json" {
-  content     = data.template_file.ext_bigip_az1_do_json.rendered
-  filename    = "${path.module}/ext_bigip_az1_do_json.json"
-}
-resource "local_file" "ext_bigip_az2_do_json" {
-  content     = data.template_file.ext_bigip_az2_do_json.rendered
-  filename    = "${path.module}/ext_bigip_az2_do_json.json"
-}
-resource "local_file" "ips_bigip_az1_do_json" {
-  content     = data.template_file.ips_bigip_az1_do_json.rendered
-  filename    = "${path.module}/ips_bigip_az1_do_json.json"
-}
-resource "local_file" "ips_bigip_az2_do_json" {
-  content     = data.template_file.ips_bigip_az2_do_json.rendered
-  filename    = "${path.module}/ips_bigip_az2_do_json.json"
-}
-resource "local_file" "internal_bigip_az1_do_json" {
-  content     = data.template_file.internal_bigip_az1_do_json.rendered
-  filename    = "${path.module}/internal_bigip_az1_do_json.json"
-}
-resource "local_file" "internal_bigip_az2_do_json" {
-  content     = data.template_file.internal_bigip_az2_do_json.rendered
-  filename    = "${path.module}/internal_bigip_az2_do_json.json"
-}
-
-provider "bigip" {
-  alias = "external_bigip_az1"
-  address = "https://${var.bigip_mgmt_ips.value.external_az1[0]}"
-  username = "admin"
-  password = data.aws_secretsmanager_secret_version.secret.secret_string
-}
-
-provider "bigip" {
-  alias = "external_bigip_az2"
-  address = "https://${var.bigip_mgmt_ips.value.external_az2[0]}"
-  username = "admin"
-  password = data.aws_secretsmanager_secret_version.secret.secret_string
-}
-
-provider "bigip" {
-  alias = "ips_bigip_az1"
-  address = "https://${var.bigip_mgmt_ips.value.ips_az1[0]}"
-  username = "admin"
-  password = data.aws_secretsmanager_secret_version.secret.secret_string
-}
-
-provider "bigip" {
-  alias = "ips_bigip_az2"
-  address = "https://${var.bigip_mgmt_ips.value.ips_az2[0]}"
-  username = "admin"
-  password = data.aws_secretsmanager_secret_version.secret.secret_string
-}
-
-provider "bigip" {
-  alias = "internal_bigip_az1"
-  address = "https://${var.bigip_mgmt_ips.value.internal_az1[0]}"
-  username = "admin"
-  password = data.aws_secretsmanager_secret_version.secret.secret_string
-}
-
-provider "bigip" {
-  alias = "internal_bigip_az2"
-  address = "https://${var.bigip_mgmt_ips.value.internal_az2[0]}"
-  username = "admin"
-  password = data.aws_secretsmanager_secret_version.secret.secret_string
-}
 
 resource "bigip_do"  "external_bigip_az1" {
      provider = bigip.external_bigip_az1
      do_json =  data.template_file.ext_bigip_az1_do_json.rendered
-     tenant_name = "external_bigip_az1"
  }
 
 resource "bigip_do"  "external_bigip_az2" {
      provider = bigip.external_bigip_az2
      do_json =  data.template_file.ext_bigip_az2_do_json.rendered
-     tenant_name = "external_bigip_az2"
  }
 
 resource "bigip_do"  "ips_bigip_az1" {
      provider = bigip.ips_bigip_az1
      do_json =  data.template_file.ips_bigip_az1_do_json.rendered
-     tenant_name = "ips_bigip_az1"
  }
 
 resource "bigip_do"  "ips_bigip_az2" {
      provider = bigip.ips_bigip_az2
      do_json =  data.template_file.ips_bigip_az2_do_json.rendered
-     tenant_name = "ips_bigip_az2"
  }
 
 resource "bigip_do"  "internal_bigip_az1" {
      provider = bigip.internal_bigip_az1
      do_json =  data.template_file.internal_bigip_az1_do_json.rendered
-     tenant_name = "internal_bigip_az1"
  }
 
 resource "bigip_do"  "internal_bigip_az2" {
      provider = bigip.internal_bigip_az2
      do_json =  data.template_file.internal_bigip_az2_do_json.rendered
-     tenant_name = "internal_bigip_az2"
  }
  
 

--- a/sca/configuration_stack/provider.tf
+++ b/sca/configuration_stack/provider.tf
@@ -3,8 +3,7 @@ provider "aws" {
 }
 
 provider "bigip" {
-  #version = "~> 1.2"
-  version = "1.1.2"
+  version = "~> 1.2"
   alias = "external_bigip_az1"
   address = "https://${var.bigip_mgmt_ips.value.external_az1[0]}"
   username = "admin"
@@ -12,8 +11,7 @@ provider "bigip" {
 }
 
 provider "bigip" {
-  #version = "~> 1.2"
-  version = "1.1.2"
+  version = "~> 1.2"
   alias = "external_bigip_az2"
   address = "https://${var.bigip_mgmt_ips.value.external_az2[0]}"
   username = "admin"
@@ -21,8 +19,7 @@ provider "bigip" {
 }
 
 provider "bigip" {
-  #version = "~> 1.2"
-  version = "1.1.2"
+  version = "~> 1.2"
   alias = "ips_bigip_az1"
   address = "https://${var.bigip_mgmt_ips.value.ips_az1[0]}"
   username = "admin"
@@ -30,8 +27,7 @@ provider "bigip" {
 }
 
 provider "bigip" {
-  #version = "~> 1.2"
-  version = "1.1.2"
+  version = "~> 1.2"
   alias = "ips_bigip_az2"
   address = "https://${var.bigip_mgmt_ips.value.ips_az2[0]}"
   username = "admin"
@@ -39,8 +35,7 @@ provider "bigip" {
 }
 
 provider "bigip" {
-  #version = "~> 1.2"
-  version = "1.1.2"
+  version = "~> 1.2"
   alias = "internal_bigip_az1"
   address = "https://${var.bigip_mgmt_ips.value.internal_az1[0]}"
   username = "admin"
@@ -48,8 +43,7 @@ provider "bigip" {
 }
 
 provider "bigip" {
-  #version = "~> 1.2"
-  version = "1.1.2"
+  version = "~> 1.2"
   alias = "internal_bigip_az2"
   address = "https://${var.bigip_mgmt_ips.value.internal_az2[0]}"
   username = "admin"

--- a/sca/configuration_stack/provider.tf
+++ b/sca/configuration_stack/provider.tf
@@ -3,7 +3,8 @@ provider "aws" {
 }
 
 provider "bigip" {
-  version = "~> 1.2"
+  #version = "~> 1.2"
+  version = "1.1.2"
   alias = "external_bigip_az1"
   address = "https://${var.bigip_mgmt_ips.value.external_az1[0]}"
   username = "admin"
@@ -11,7 +12,8 @@ provider "bigip" {
 }
 
 provider "bigip" {
-  version = "~> 1.2"
+  #version = "~> 1.2"
+  version = "1.1.2"
   alias = "external_bigip_az2"
   address = "https://${var.bigip_mgmt_ips.value.external_az2[0]}"
   username = "admin"
@@ -19,7 +21,8 @@ provider "bigip" {
 }
 
 provider "bigip" {
-  version = "~> 1.2"
+  #version = "~> 1.2"
+  version = "1.1.2"
   alias = "ips_bigip_az1"
   address = "https://${var.bigip_mgmt_ips.value.ips_az1[0]}"
   username = "admin"
@@ -27,7 +30,8 @@ provider "bigip" {
 }
 
 provider "bigip" {
-  version = "~> 1.2"
+  #version = "~> 1.2"
+  version = "1.1.2"
   alias = "ips_bigip_az2"
   address = "https://${var.bigip_mgmt_ips.value.ips_az2[0]}"
   username = "admin"
@@ -35,7 +39,8 @@ provider "bigip" {
 }
 
 provider "bigip" {
-  version = "~> 1.2"
+  #version = "~> 1.2"
+  version = "1.1.2"
   alias = "internal_bigip_az1"
   address = "https://${var.bigip_mgmt_ips.value.internal_az1[0]}"
   username = "admin"
@@ -43,7 +48,8 @@ provider "bigip" {
 }
 
 provider "bigip" {
-  version = "~> 1.2"
+  #version = "~> 1.2"
+  version = "1.1.2"
   alias = "internal_bigip_az2"
   address = "https://${var.bigip_mgmt_ips.value.internal_az2[0]}"
   username = "admin"

--- a/sca/configuration_stack/provider.tf
+++ b/sca/configuration_stack/provider.tf
@@ -1,3 +1,51 @@
 provider "aws" {
   region = var.aws_region.value
 }
+
+provider "bigip" {
+  version = "~> 1.2"
+  alias = "external_bigip_az1"
+  address = "https://${var.bigip_mgmt_ips.value.external_az1[0]}"
+  username = "admin"
+  password = data.aws_secretsmanager_secret_version.secret.secret_string
+}
+
+provider "bigip" {
+  version = "~> 1.2"
+  alias = "external_bigip_az2"
+  address = "https://${var.bigip_mgmt_ips.value.external_az2[0]}"
+  username = "admin"
+  password = data.aws_secretsmanager_secret_version.secret.secret_string
+}
+
+provider "bigip" {
+  version = "~> 1.2"
+  alias = "ips_bigip_az1"
+  address = "https://${var.bigip_mgmt_ips.value.ips_az1[0]}"
+  username = "admin"
+  password = data.aws_secretsmanager_secret_version.secret.secret_string
+}
+
+provider "bigip" {
+  version = "~> 1.2"
+  alias = "ips_bigip_az2"
+  address = "https://${var.bigip_mgmt_ips.value.ips_az2[0]}"
+  username = "admin"
+  password = data.aws_secretsmanager_secret_version.secret.secret_string
+}
+
+provider "bigip" {
+  version = "~> 1.2"
+  alias = "internal_bigip_az1"
+  address = "https://${var.bigip_mgmt_ips.value.internal_az1[0]}"
+  username = "admin"
+  password = data.aws_secretsmanager_secret_version.secret.secret_string
+}
+
+provider "bigip" {
+  version = "~> 1.2"
+  alias = "internal_bigip_az2"
+  address = "https://${var.bigip_mgmt_ips.value.internal_az2[0]}"
+  username = "admin"
+  password = data.aws_secretsmanager_secret_version.secret.secret_string
+}

--- a/sca/configuration_stack/templates/as3/as3.tmpl
+++ b/sca/configuration_stack/templates/as3/as3.tmpl
@@ -1,0 +1,35 @@
+{
+    "class": "AS3",
+    "action": "deploy",
+    "persist": true,
+    "logLevel": "info",
+    "declaration": {
+        "class": "ADC",
+        "schemaVersion": "3.5.0",
+        "id": "urn:uuid:b92236ad-a677-4574-8bce-7d1487aeb62f",
+        "label": "baseline",
+        "remark": "baseline VIPs",
+        "baseline": {
+            "class": "Tenant",
+	        "forward_outbound": {
+                "class": "Application",
+                "template": "generic",
+                "forward_outbound": {
+                    "class": "Service_L4",
+                    "layer4": "any",
+                    "translateServerAddress": false,
+                    "translateServerPort": false,
+                    "virtualAddresses": [
+                        "${virtualAddress}"
+                    ],
+                    "virtualPort": 0,
+                    "snat": "auto",
+                    "allowVlans": 
+                    [
+                        "${allowedVlan}"
+                    ]
+                }
+            }
+	}
+    }
+}

--- a/sca/configuration_stack/templates/cloudFailoverExtension/cfe.json
+++ b/sca/configuration_stack/templates/cloudFailoverExtension/cfe.json
@@ -16,12 +16,13 @@
       }
     },
     "failoverRoutes":{
+      "enabled": true,
       "scopingTags":{
-      "f5_cloud_failover_label":"${label}"
+      "f5_cloud_failover_label":"${labelRouteTable}"
       },
       "scopingAddressRanges":[
            {
-             "range":"192.168.100.0/24"
+             "range":"${range}"
            }
        ],
       "defaultNextHopAddresses":{

--- a/sca/configuration_stack/variables.tf
+++ b/sca/configuration_stack/variables.tf
@@ -42,3 +42,7 @@ variable uname {
     default = "admin"
 }
 variable secrets_manager_name {}
+
+variable cfe_bucket_external {}
+variable cfe_bucket_internal {}
+variable CFE_route_tables {}

--- a/sca/security_stack/cfe_bucket.tf
+++ b/sca/security_stack/cfe_bucket.tf
@@ -10,3 +10,14 @@ resource "aws_s3_bucket" "cfe_external_bucket" {
   }
 }
 
+resource "aws_s3_bucket" "cfe_internal_bucket" {
+  #Error: expected length of bucket_prefix to be in the range (0 - 37), got mydeployment-sca-tf--cfe-external-bucket-4bf0
+  bucket_prefix = format(
+    "%s-cfe-internal-bucket-%s",
+    var.project.value,
+    var.random_id.value
+  )
+  tags = {
+   f5_cloud_failover_label = format( "%s-internal-%s", var.project.value, var.random_id.value )
+  }
+}

--- a/sca/security_stack/internal.tf
+++ b/sca/security_stack/internal.tf
@@ -117,7 +117,7 @@ data "template_file" "internal_onboard_az1" {
     #egressCh1Gateway   =  var.aws_cidr_ips.value.az1.security.egress_to_ch1
     #egressCh2Gateway   =  var.aws_cidr_ips.value.az1.security.egress_to_ch2
     #internalGateway    =  var.aws_cidr_ips.value.az1.security.internal
-    externalGateway    =  var.aws_cidr_ips.value.az1.security.dmz_inside
+    externalGateway    =  var.aws_cidr_ips.value.az1.security.application_region
     #mgmtGateway        =  var.aws_cidr_ips.value.az1.security.mgmt
     #peeringGateway     =  var.aws_cidr_ips.value.az1.security.peering
     # networks
@@ -156,7 +156,7 @@ data "template_file" "internal_onboard_az2" {
     #egressCh1Gateway   =  var.aws_cidr_ips.value.az2.security.egress_to_ch1
     #egressCh2Gateway   =  var.aws_cidr_ips.value.az2.security.egress_to_ch2
     #internalGateway    =  var.aws_cidr_ips.value.az2.security.internal
-    externalGateway    =  var.aws_cidr_ips.value.az2.security.dmz_inside
+    externalGateway    =  var.aws_cidr_ips.value.az2.security.application_region
     #mgmtGateway        =  var.aws_cidr_ips.value.az2.security.mgmt
     #peeringGateway     =  var.aws_cidr_ips.value.az2.security.peering
     # networks

--- a/sca/security_stack/ips.tf
+++ b/sca/security_stack/ips.tf
@@ -117,7 +117,7 @@ data "template_file" "ips_onboard_az1" {
     #egressCh1Gateway   =  var.aws_cidr_ips.value.az1.security.egress_to_ch1
     #egressCh2Gateway   =  var.aws_cidr_ips.value.az1.security.egress_to_ch2
     #internalGateway    =  var.aws_cidr_ips.value.az1.security.internal
-    externalGateway    =  var.aws_cidr_ips.value.az1.security.dmz_outside
+    externalGateway    =  var.aws_cidr_ips.value.az1.security.application_region
     #mgmtGateway        =  var.aws_cidr_ips.value.az1.security.mgmt
     #peeringGateway     =  var.aws_cidr_ips.value.az1.security.peering
     # networks
@@ -156,7 +156,7 @@ data "template_file" "ips_onboard_az2" {
     #egressCh1Gateway   =  var.aws_cidr_ips.value.az2.security.egress_to_ch1
     #egressCh2Gateway   =  var.aws_cidr_ips.value.az2.security.egress_to_ch2
     #internalGateway    =  var.aws_cidr_ips.value.az2.security.internal
-    externalGateway    =  var.aws_cidr_ips.value.az2.security.dmz_outside
+    externalGateway    =  var.aws_cidr_ips.value.az2.security.application_region
     #mgmtGateway        =  var.aws_cidr_ips.value.az2.security.mgmt
     #peeringGateway     =  var.aws_cidr_ips.value.az2.security.peering
     # networks

--- a/sca/security_stack/output.tf
+++ b/sca/security_stack/output.tf
@@ -95,3 +95,13 @@ output "bigip_map" {
     internal_az2 = module.internal_az2.bigip_map
   }
 }
+
+# CFE bucket details
+output "cfe_bucket_external" {
+  description = "Details of CFE bucket for external tier"
+  value = aws_s3_bucket.cfe_external_bucket
+}
+output "cfe_bucket_internal" {
+  description = "Details of CFE bucket for internal tier"
+  value = aws_s3_bucket.cfe_internal_bucket
+}

--- a/sca/security_stack/templates/bigip_onboard.tmpl
+++ b/sca/security_stack/templates/bigip_onboard.tmpl
@@ -450,7 +450,7 @@ submit cli transaction" | tmsh -q
 echo -e "create cli transaction;
 create net route /LOCAL_ONLY/default network 0.0.0.0/0 gw $externalGateway
 create net route /LOCAL_ONLY/application network $syncNetwork gw $applicationGateway
-create net route /LOCAL_ONLY/internal network 10.0.0.0/16 gw $internalGateway
+create net route /LOCAL_ONLY/internal network 10.0.0.0/8 gw $internalGateway
 submit cli transaction" | tmsh -q 
 # END TMSH NETWORKING
 ### Clean up

--- a/sca/security_stack/variables.tf
+++ b/sca/security_stack/variables.tf
@@ -14,9 +14,9 @@ variable "atc_versions" {
   type        = map(string)
   default = {
     doVersion   = "1.12.0"
-    as3Version  = "3.13.2"
+    as3Version  = "3.20.0"
     tsVersion   = "1.11.0"
-    cfVersion   = "1.2.0"
+    cfVersion   = "1.3.0"
     fastVersion = "0.2.0"
   }
 }


### PR DESCRIPTION
- this PR includes updates to the ConfigurationStack to allow config of BIG-IP devices after they are deployed.

The order of modules to deploy and steps to follow are now as follows:
1) core module
2) security module
3) manually run security module a second time to fix known issue of incomplete outputs
4) manually create a route for 0.0.0.0/0 in internal route table pointing to eth3 ENI of BIG-IPs on internal tier.
5) manually tag required ENI's (eth1 on external tier devices, and eth3 on internal tier devices
6) configuration module

